### PR TITLE
PSR-516 | WhenWasTransferMade implementation and refactoring

### DIFF
--- a/app/controllers/nonsipp/membertransferout/WhenWasTransferMadeController.scala
+++ b/app/controllers/nonsipp/membertransferout/WhenWasTransferMadeController.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.nonsipp.membertransferout
+
+import cats.implicits.toShow
+import config.Refined.{Max300, Max5}
+import controllers.PSRController
+import controllers.actions.IdentifyAndRequireData
+import forms.DatePageFormProvider
+import forms.mappings.errors.DateFormErrors
+import models.{DateRange, Mode}
+import models.SchemeId.Srn
+import navigation.Navigator
+import pages.nonsipp.memberdetails.MemberDetailsPage
+import pages.nonsipp.membertransferout.{ReceivingSchemeNamePage, WhenWasTransferMadePage}
+import play.api.data.Form
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.{SaveService, SchemeDateService}
+import utils.DateTimeUtils.localDateShow
+import viewmodels.DisplayMessage.Message
+import viewmodels.models.{DatePageViewModel, FormPageViewModel}
+import views.html.DatePageView
+import viewmodels.implicits._
+
+import java.time.LocalDate
+import javax.inject.{Inject, Named}
+import scala.concurrent.{ExecutionContext, Future}
+
+class WhenWasTransferMadeController @Inject()(
+  override val messagesApi: MessagesApi,
+  saveService: SaveService,
+  @Named("non-sipp") navigator: Navigator,
+  identifyAndRequireData: IdentifyAndRequireData,
+  formProvider: DatePageFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  schemeDateService: SchemeDateService,
+  view: DatePageView
+)(implicit ec: ExecutionContext)
+    extends PSRController {
+
+  private def form(date: DateRange)(implicit messages: Messages) =
+    WhenWasTransferMadeController.form(formProvider, date)
+
+  def onPageLoad(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode): Action[AnyContent] =
+    identifyAndRequireData(srn) { implicit request =>
+      (
+        for {
+          member <- request.userAnswers.get(MemberDetailsPage(srn, index)).getOrRecoverJourney
+          date <- schemeDateService.taxYearOrAccountingPeriods(srn).merge.getOrRecoverJourney
+          schemeName <- request.userAnswers
+            .get(ReceivingSchemeNamePage(srn, index, secondaryIndex))
+            .getOrRecoverJourney
+        } yield {
+          val preparedForm = request.userAnswers
+            .get(WhenWasTransferMadePage(srn, index, secondaryIndex))
+            .fold(form(date))(form(date).fill)
+          Ok(
+            view(
+              preparedForm,
+              WhenWasTransferMadeController.viewModel(srn, index, secondaryIndex, schemeName, member.fullName, mode)
+            )
+          )
+        }
+      ).merge
+    }
+
+  def onSubmit(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode): Action[AnyContent] =
+    identifyAndRequireData(srn).async { implicit request =>
+      schemeDateService.taxYearOrAccountingPeriods(srn).merge.getOrRecoverJourney { date =>
+        form(date)
+          .bindFromRequest()
+          .fold(
+            formWithErrors => {
+              Future.successful(
+                (
+                  for {
+                    member <- request.userAnswers.get(MemberDetailsPage(srn, index)).getOrRecoverJourney
+                    schemeName <- request.userAnswers
+                      .get(ReceivingSchemeNamePage(srn, index, secondaryIndex))
+                      .getOrRecoverJourney
+                  } yield {
+                    BadRequest(
+                      view(
+                        formWithErrors,
+                        WhenWasTransferMadeController
+                          .viewModel(srn, index, secondaryIndex, schemeName, member.fullName, mode)
+                      )
+                    )
+                  }
+                ).merge
+              )
+            },
+            value =>
+              for {
+                updatedAnswers <- Future
+                  .fromTry(request.userAnswers.set(WhenWasTransferMadePage(srn, index, secondaryIndex), value))
+                _ <- saveService.save(updatedAnswers)
+              } yield Redirect(
+                navigator.nextPage(WhenWasTransferMadePage(srn, index, secondaryIndex), mode, updatedAnswers)
+              )
+          )
+      }
+    }
+}
+
+object WhenWasTransferMadeController {
+  def form(formProvider: DatePageFormProvider, date: DateRange)(implicit messages: Messages): Form[LocalDate] =
+    formProvider(
+      DateFormErrors(
+        required = "transferOut.transferMade.error.required.all",
+        requiredDay = "transferOut.transferMade.error.required.day",
+        requiredMonth = "transferOut.transferMade.error.required.month",
+        requiredYear = "transferOut.transferMade.error.required.year",
+        requiredTwo = "transferOut.transferMade.error.required.two",
+        invalidDate = "transferOut.transferMade.error.invalid.date",
+        invalidCharacters = "transferOut.transferMade.error.invalid.chars",
+        validators = List(
+          DateFormErrors
+            .failIfDateAfter(date.to, messages("transferOut.transferMade.error.date.after", date.to.show)),
+          DateFormErrors
+            .failIfDateBefore(
+              date.from,
+              messages("transferOut.transferMade.error.date.before", date.from.show)
+            )
+        )
+      )
+    )
+
+  def viewModel(
+    srn: Srn,
+    index: Max300,
+    secondaryIndex: Max5,
+    schemeName: String,
+    memberName: String,
+    mode: Mode
+  ): FormPageViewModel[DatePageViewModel] =
+    FormPageViewModel(
+      "transferOut.transferMade.title",
+      Message("transferOut.transferMade.heading", schemeName, memberName),
+      DatePageViewModel(),
+      controllers.nonsipp.membertransferout.routes.WhenWasTransferMadeController
+        .onSubmit(srn, index, secondaryIndex, mode)
+    )
+}

--- a/app/navigation/nonsipp/TransferOutNavigator.scala
+++ b/app/navigation/nonsipp/TransferOutNavigator.scala
@@ -44,6 +44,10 @@ object TransferOutNavigator extends JourneyNavigator {
         .onPageLoad(srn, index, transferIndex, NormalMode)
 
     case ReceivingSchemeTypePage(srn, index, transferIndex) =>
+      controllers.nonsipp.membertransferout.routes.WhenWasTransferMadeController
+        .onPageLoad(srn, index, transferIndex, NormalMode)
+
+    case WhenWasTransferMadePage(srn, index, transferIndex) =>
       controllers.routes.UnauthorisedController.onPageLoad()
 
   }

--- a/app/pages/nonsipp/membertransferout/WhenWasTransferMadePage.scala
+++ b/app/pages/nonsipp/membertransferout/WhenWasTransferMadePage.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.nonsipp.membertransferout
+
+import config.Refined.{Max300, Max5}
+import models.SchemeId.Srn
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+import utils.RefinedUtils.RefinedIntOps
+
+import java.time.LocalDate
+
+case class WhenWasTransferMadePage(srn: Srn, index: Max300, secondaryIndex: Max5) extends QuestionPage[LocalDate] {
+
+  override def path: JsPath =
+    Paths.memberTransfersOut \ toString \ index.arrayIndex.toString \ secondaryIndex.arrayIndex.toString
+
+  override def toString: String = "dateOfTransfer"
+}

--- a/conf/memberpayments_transferout.routes
+++ b/conf/memberpayments_transferout.routes
@@ -24,3 +24,8 @@ POST        /:srn/receiving-scheme-type/:index/:secondaryIndex                  
 
 GET         /:srn/change-receiving-scheme-type/:index/:secondaryIndex                   controllers.nonsipp.membertransferout.ReceivingSchemeTypeController.onPageLoad(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode = CheckMode)
 POST        /:srn/change-receiving-scheme-type/:index/:secondaryIndex                   controllers.nonsipp.membertransferout.ReceivingSchemeTypeController.onSubmit(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode = CheckMode)
+
+GET        /:srn/when-was-transfer-made/:index/:secondaryIndex                          controllers.nonsipp.membertransferout.WhenWasTransferMadeController.onPageLoad(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode = NormalMode)
+POST       /:srn/when-was-transfer-made/:index/:secondaryIndex                          controllers.nonsipp.membertransferout.WhenWasTransferMadeController.onSubmit(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode = NormalMode)
+GET        /:srn/change-when-was-transfer-made/:index/:secondaryIndex                   controllers.nonsipp.membertransferout.WhenWasTransferMadeController.onPageLoad(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode = CheckMode)
+POST       /:srn/change-when-was-transfer-made/:index/:secondaryIndex                   controllers.nonsipp.membertransferout.WhenWasTransferMadeController.onSubmit(srn: Srn, index: Max300, secondaryIndex: Max5, mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1900,3 +1900,15 @@ TransferOut.receivingSchemeName.error.invalid = Receiving scheme’s name must o
 TransferOut.receivingSchemeName.error.tooLong = Receiving scheme’s name must be 160 characters or fewer
 
 transferOut.pensionType.title = What type of scheme is the receiving scheme?
+
+transferOut.transferMade.title = When was this transfer for this member made?
+transferOut.transferMade.heading = When was the transfer to {0} for {1} made?
+transferOut.transferMade.error.required.day = Date the transfer was made must include day
+transferOut.transferMade.error.required.month = Date the transfer was made must include month
+transferOut.transferMade.error.required.year = Date the transfer was made must include year
+transferOut.transferMade.error.required.two = Date the transfer was made must include a {0} and {1}
+transferOut.transferMade.error.required.all = Enter the date the transfer was made
+transferOut.transferMade.error.date.before = Date the transfer was made must be after {0}
+transferOut.transferMade.error.date.after = Date the transfer was made must be before {0}
+transferOut.transferMade.error.invalid.date = Date the transfer was made must be a real date
+transferOut.transferMade.error.invalid.chars = Date the transfer was made must only include numbers 0 to 9

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -136,6 +136,7 @@ trait TestValues {
   val amountBorrowed: (Money, Percentage) = (money, percentage)
   val reasonBorrowed = "test reason borrowed"
   val transferringSchemeName = "transferring scheme"
+  val receivingSchemeName = "receiving scheme"
 
   val address: Address = Address(
     "test-id",

--- a/test/controllers/nonsipp/membertransferout/WhenWasTransferMadeControllerSpec.scala
+++ b/test/controllers/nonsipp/membertransferout/WhenWasTransferMadeControllerSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.nonsipp.membertransferout
+
+import config.Refined.{Max300, Max5}
+import controllers.ControllerBaseSpec
+import eu.timepit.refined.refineMV
+import forms.DatePageFormProvider
+import models.NormalMode
+import pages.nonsipp.memberdetails.MemberDetailsPage
+import pages.nonsipp.membertransferout.{ReceivingSchemeNamePage, WhenWasTransferMadePage}
+import play.api.inject
+import play.api.inject.guice.GuiceableModule
+import services.SchemeDateService
+import views.html.DatePageView
+
+class WhenWasTransferMadeControllerSpec extends ControllerBaseSpec {
+
+  private val index = refineMV[Max300.Refined](1)
+  private val secondaryIndex = refineMV[Max5.Refined](1)
+  private lazy val onPageLoad =
+    routes.WhenWasTransferMadeController.onPageLoad(srn, index, secondaryIndex, NormalMode)
+  private lazy val onSubmit = routes.WhenWasTransferMadeController.onSubmit(srn, index, secondaryIndex, NormalMode)
+
+  private implicit val mockSchemeDateService = mock[SchemeDateService]
+
+  override val additionalBindings: List[GuiceableModule] =
+    List(inject.bind[SchemeDateService].toInstance(mockSchemeDateService))
+
+  override def beforeEach(): Unit = {
+    reset(mockSchemeDateService)
+    MockSchemeDateService.taxYearOrAccountingPeriods(Some(Left(dateRange)))
+  }
+
+  val userAnswers = defaultUserAnswers
+    .unsafeSet(MemberDetailsPage(srn, index), memberDetails)
+    .unsafeSet(ReceivingSchemeNamePage(srn, index, secondaryIndex), receivingSchemeName)
+
+  "WhenWasTransferMadeController" - {
+
+    act.like(renderView(onPageLoad, userAnswers) { implicit app => implicit request =>
+      injected[DatePageView]
+        .apply(
+          WhenWasTransferMadeController.form(injected[DatePageFormProvider], dateRange),
+          WhenWasTransferMadeController
+            .viewModel(srn, index, secondaryIndex, receivingSchemeName, memberDetails.fullName, NormalMode)
+        )
+    })
+
+    act.like(
+      renderPrePopView(onPageLoad, WhenWasTransferMadePage(srn, index, secondaryIndex), dateRange.to, userAnswers) {
+        implicit app => implicit request =>
+          injected[DatePageView].apply(
+            WhenWasTransferMadeController.form(injected[DatePageFormProvider], dateRange).fill(dateRange.to),
+            WhenWasTransferMadeController
+              .viewModel(srn, index, secondaryIndex, receivingSchemeName, memberDetails.fullName, NormalMode)
+          )
+      }
+    )
+
+    act.like(
+      redirectNextPage(onSubmit, userAnswers, "value.day" -> "10", "value.month" -> "06", "value.year" -> "2020")
+    )
+
+    act.like(journeyRecoveryPage(onPageLoad).updateName("onPageLoad" + _))
+
+    act.like(saveAndContinue(onSubmit, userAnswers, "value.day" -> "10", "value.month" -> "06", "value.year" -> "2020"))
+
+    act.like(invalidForm(onSubmit, userAnswers))
+
+    act.like(journeyRecoveryPage(onSubmit).updateName("onSubmit" + _))
+  }
+}

--- a/test/pages/nonsipp/membertransferout/ReceivingSchemeNamePageSpec.scala
+++ b/test/pages/nonsipp/membertransferout/ReceivingSchemeNamePageSpec.scala
@@ -14,19 +14,24 @@
  * limitations under the License.
  */
 
-package pages.nonsipp.membertransfersout
+package pages.nonsipp.membertransferout
 
+import config.Refined.{OneTo300, OneTo5}
+import eu.timepit.refined.refineMV
 import pages.behaviours.PageBehaviours
-import pages.nonsipp.membertransferout.SchemeTransferOutPage
+import pages.nonsipp.membertransferout.ReceivingSchemeNamePage
 
-class SchemeTransferoutPageSpec extends PageBehaviours {
+class ReceivingSchemeNamePageSpec extends PageBehaviours {
 
-  "SchemeTransferoutPage" - {
+  "ReceivingSchemeNamePage" - {
 
-    beRetrievable[Boolean](SchemeTransferOutPage(srnGen.sample.value))
+    val index = refineMV[OneTo300](1)
+    val transferIndex = refineMV[OneTo5](1)
 
-    beSettable[Boolean](SchemeTransferOutPage(srnGen.sample.value))
+    beRetrievable[String](ReceivingSchemeNamePage(srnGen.sample.value, index, transferIndex))
 
-    beRemovable[Boolean](SchemeTransferOutPage(srnGen.sample.value))
+    beSettable[String](ReceivingSchemeNamePage(srnGen.sample.value, index, transferIndex))
+
+    beRemovable[String](ReceivingSchemeNamePage(srnGen.sample.value, index, transferIndex))
   }
 }

--- a/test/pages/nonsipp/membertransferout/SchemeTransferoutPageSpec.scala
+++ b/test/pages/nonsipp/membertransferout/SchemeTransferoutPageSpec.scala
@@ -14,24 +14,19 @@
  * limitations under the License.
  */
 
-package pages.nonsipp.membertransfersout
+package pages.nonsipp.membertransferout
 
-import config.Refined.{OneTo300, OneTo5}
-import eu.timepit.refined.refineMV
 import pages.behaviours.PageBehaviours
-import pages.nonsipp.membertransferout.ReceivingSchemeNamePage
+import pages.nonsipp.membertransferout.SchemeTransferOutPage
 
-class ReceivingSchemeNamePageSpec extends PageBehaviours {
+class SchemeTransferoutPageSpec extends PageBehaviours {
 
-  "ReceivingSchemeNamePage" - {
+  "SchemeTransferoutPage" - {
 
-    val index = refineMV[OneTo300](1)
-    val transferIndex = refineMV[OneTo5](1)
+    beRetrievable[Boolean](SchemeTransferOutPage(srnGen.sample.value))
 
-    beRetrievable[String](ReceivingSchemeNamePage(srnGen.sample.value, index, transferIndex))
+    beSettable[Boolean](SchemeTransferOutPage(srnGen.sample.value))
 
-    beSettable[String](ReceivingSchemeNamePage(srnGen.sample.value, index, transferIndex))
-
-    beRemovable[String](ReceivingSchemeNamePage(srnGen.sample.value, index, transferIndex))
+    beRemovable[Boolean](SchemeTransferOutPage(srnGen.sample.value))
   }
 }

--- a/test/pages/nonsipp/membertransferout/WhenWasTransferMadePageSpec.scala
+++ b/test/pages/nonsipp/membertransferout/WhenWasTransferMadePageSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.nonsipp.membertransferout
+
+import config.Refined.{Max300, Max5}
+import eu.timepit.refined.refineMV
+import pages.behaviours.PageBehaviours
+import pages.nonsipp.membertransferout.WhenWasTransferMadePage
+
+import java.time.LocalDate
+
+class WhenWasTransferMadePageSpec extends PageBehaviours {
+
+  "WhenWasTransferMadePage" - {
+
+    val index = refineMV[Max300.Refined](1)
+    val secondaryIndex = refineMV[Max5.Refined](1)
+
+    beRetrievable[LocalDate](WhenWasTransferMadePage(srnGen.sample.value, index, secondaryIndex))
+
+    beSettable[LocalDate](WhenWasTransferMadePage(srnGen.sample.value, index, secondaryIndex))
+
+    beRemovable[LocalDate](WhenWasTransferMadePage(srnGen.sample.value, index, secondaryIndex))
+  }
+}


### PR DESCRIPTION
Note:

- The package `pages.nonsipp.membertransfersout` has been renamed to `pages.nonsipp.membertransferout` for consistency with the other `membertransferout` packages.
- I've created the val `receivingSchemeName` in `BaseControllerSpec` to follow the implementation for the transfer in journey, but if there is a better way of doing so, or if it would be better to use the existing `transferringSchemeName` val, please let me know!