### PR TITLE
PSR-1127 Fixed back button app crash on upload journey

### DIFF
--- a/app/models/Upload.scala
+++ b/app/models/Upload.scala
@@ -58,6 +58,18 @@ object ValidationError {
     ValidationError(cell + (row + 1), errorType: ValidationErrorType, errorMessage)
 }
 
+// Used to track the state of the upload user journey. This is separate from the actual Upload payload state
+sealed trait UploadJourneyStatus
+
+case object UploadInitiated extends UploadJourneyStatus
+case object UploadSubmitted extends UploadJourneyStatus
+
+object UploadJourneyStatus {
+  implicit val formatUploadInitiated: Format[UploadInitiated.type] = Json.format[UploadInitiated.type]
+  implicit val formatUploadSubmitted: Format[UploadSubmitted.type] = Json.format[UploadSubmitted.type]
+  implicit val formatUploadJourneyStatus: Format[UploadJourneyStatus] = Json.format[UploadJourneyStatus]
+}
+
 case class UploadState(row: Int, previousNinos: List[Nino]) {
   def next(nino: Option[Nino] = None): UploadState =
     UploadState(row + 1, previousNinos :?+ nino)

--- a/app/pages/nonsipp/memberdetails/upload/UploadStatusPage.scala
+++ b/app/pages/nonsipp/memberdetails/upload/UploadStatusPage.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.nonsipp.memberdetails.upload
+
+import pages.QuestionPage
+import models.SchemeId.Srn
+import play.api.libs.json.JsPath
+import models.UploadJourneyStatus
+
+case class UploadStatusPage(srn: Srn) extends QuestionPage[UploadJourneyStatus] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "uploadJourneyStatus"
+}

--- a/test/controllers/nonsipp/memberdetails/UploadMemberDetailsControllerSpec.scala
+++ b/test/controllers/nonsipp/memberdetails/UploadMemberDetailsControllerSpec.scala
@@ -120,10 +120,8 @@ class UploadMemberDetailsControllerSpec extends ControllerBaseSpec {
         })
     )
 
-    act.like(journeyRecoveryPage(onPageLoad).updateName("onPageLoad" + _))
-
-    act.like(continueNoSave(onSubmit))
-    act.like(journeyRecoveryPage(onSubmit).updateName("onSubmit" + _))
+    act.like(journeyRecoveryPage(onPageLoad).updateName("onPageLoad " + _))
+    act.like(journeyRecoveryPage(onSubmit).updateName("onSubmit " + _))
   }
 
   private def mockInitiateUpscan(): Unit =

--- a/test/controllers/nonsipp/memberdetails/upload/CheckingMemberDetailsFileControllerSpec.scala
+++ b/test/controllers/nonsipp/memberdetails/upload/CheckingMemberDetailsFileControllerSpec.scala
@@ -20,10 +20,11 @@ import services.UploadService
 import controllers.ControllerBaseSpec
 import views.html.ContentPageView
 import play.api.inject
+import pages.nonsipp.memberdetails.upload.UploadStatusPage
 import org.mockito.ArgumentMatchers.any
 import play.api.inject.guice.GuiceableModule
 import org.mockito.Mockito.{reset, when}
-import models.{NormalMode, Upload}
+import models._
 import controllers.nonsipp.memberdetails.upload.CheckingMemberDetailsFileController._
 
 import scala.concurrent.Future
@@ -44,9 +45,14 @@ class CheckingMemberDetailsFileControllerSpec extends ControllerBaseSpec {
 
   "CheckingMemberDetailsFileController" - {
 
-    act.like(renderView(onPageLoad) { implicit app => implicit request =>
-      injected[ContentPageView].apply(viewModel(srn, NormalMode))
-    })
+    act.like(
+      renderView(
+        onPageLoad,
+        defaultUserAnswers.unsafeSet(UploadStatusPage(srn), UploadSubmitted)
+      ) { implicit app => implicit request =>
+        injected[ContentPageView].apply(viewModel(srn, NormalMode))
+      }.before(mockGetUploadResult(Some(uploadResultSuccess)))
+    )
 
     act.like(
       redirectToPage(onSubmit, routes.FileUploadSuccessController.onPageLoad(srn, NormalMode))

--- a/test/services/PsrSubmissionServiceSpec.scala
+++ b/test/services/PsrSubmissionServiceSpec.scala
@@ -40,6 +40,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+
 import java.time.LocalDate
 
 class PsrSubmissionServiceSpec extends BaseSpec with TestValues {

--- a/test/transformations/MinimalRequiredSubmissionTransformerSpec.scala
+++ b/test/transformations/MinimalRequiredSubmissionTransformerSpec.scala
@@ -28,17 +28,17 @@ import eu.timepit.refined.refineMV
 import pages.nonsipp.accountingperiod.{AccountingPeriodPage, AccountingPeriodRecordVersionPage, AccountingPeriods}
 import utils.UserAnswersUtils.UserAnswersOps
 import generators.ModelGenerators.allowedAccessRequestGen
+import viewmodels.models.{Compiled, Submitted}
 import models.requests.{AllowedAccessRequest, DataRequest}
 import org.mockito.Mockito
 import org.scalatest.freespec.AnyFreeSpec
 import org.mockito.Mockito.{times, verify, when}
-import pages.nonsipp.{CheckReturnDatesPage, FbStatus, FbVersionPage, WhichTaxYearPage}
+import pages.nonsipp._
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import models._
 import models.SchemeMemberNumbers._
 import org.mockito.ArgumentMatchers.any
 import org.scalatestplus.mockito.MockitoSugar.mock
-import viewmodels.models.{Compiled, Submitted}
 
 import java.time.LocalDate
 


### PR DESCRIPTION
User now needs to submit the upload page to be redirected to the upload check page - otherwise user is sent back to the "choose upload file" page on any browser backs