### PR TITLE
PSR-1560 | Shares Check Methods

### DIFF
--- a/test/utils/nonsipp/CheckStatusUtilsSpec.scala
+++ b/test/utils/nonsipp/CheckStatusUtilsSpec.scala
@@ -16,14 +16,16 @@
 
 package utils.nonsipp
 
-import org.scalatest.matchers.must.Matchers
+import pages.nonsipp.shares._
 import models.IdentityType._
 import pages.nonsipp.landorproperty._
 import eu.timepit.refined.refineMV
 import utils.nonsipp.CheckStatusUtils._
 import models._
 import pages.nonsipp.common._
-import models.IdentitySubject.LandOrPropertySeller
+import models.IdentitySubject._
+import org.scalatest.matchers.must.Matchers
+import models.ConditionalYesNo._
 import config.RefinedTypes._
 import controllers.ControllerBaseSpec
 import org.scalatest.OptionValues
@@ -33,12 +35,94 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
 
   // Test values
   private val name: String = "name"
-  private val reason: String = "reason"
   private val index1of5000: Max5000 = refineMV(1)
   private val index2of5000: Max5000 = refineMV(2)
-  private val conditionalYesNino: ConditionalYesNo[String, Nino] = ConditionalYesNo.yes(nino)
-  private val conditionalYesCrn: ConditionalYesNo[String, Crn] = ConditionalYesNo.yes(crn)
-  private val conditionalYesUtr: ConditionalYesNo[String, Utr] = ConditionalYesNo.yes(utr)
+  private val conditionalYesNoLRTN: ConditionalYesNo[String, String] = ConditionalYesNo.yes("landRegistryTitleNumber")
+  private val conditionalYesNoNino: ConditionalYesNo[String, Nino] = ConditionalYesNo.yes(nino)
+  private val conditionalYesNoCrn: ConditionalYesNo[String, Crn] = ConditionalYesNo.yes(crn)
+  private val conditionalYesNoUtr: ConditionalYesNo[String, Utr] = ConditionalYesNo.yes(utr)
+
+//--------------------------------------------------------------------------------------------------------------------//
+
+  // Shares
+  private val didSchemeHoldAnySharesTrue = defaultUserAnswers.unsafeSet(DidSchemeHoldAnySharesPage(srn), true)
+  private val didSchemeHoldAnySharesFalse = defaultUserAnswers.unsafeSet(DidSchemeHoldAnySharesPage(srn), false)
+
+  private def addSharesBaseAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(CompanyNameRelatedSharesPage(srn, index), name)
+      .unsafeSet(SharesCompanyCrnPage(srn, index), conditionalYesNoCrn)
+      .unsafeSet(ClassOfSharesPage(srn, index), classOfShares)
+      .unsafeSet(HowManySharesPage(srn, index), totalShares)
+      .unsafeSet(CostOfSharesPage(srn, index), money)
+      .unsafeSet(SharesIndependentValuationPage(srn, index), true)
+
+  // Shares: Branching on TypeOfSharesHeldPage
+  private def addSharesSponsoringEmployerAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(TypeOfSharesHeldPage(srn, index), TypeOfShares.SponsoringEmployer)
+
+  private def addSharesUnquotedAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(TypeOfSharesHeldPage(srn, index), TypeOfShares.Unquoted)
+      .unsafeSet(SharesFromConnectedPartyPage(srn, index), true)
+
+  private def addSharesConnectedPartyAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(TypeOfSharesHeldPage(srn, index), TypeOfShares.ConnectedParty)
+
+  // Shares: Branching on WhyDoesSchemeHoldSharesPage
+  private def addSharesAcquisitionAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(WhyDoesSchemeHoldSharesPage(srn, index), SchemeHoldShare.Acquisition)
+      .unsafeSet(WhenDidSchemeAcquireSharesPage(srn, index), localDate)
+
+  private def addSharesContributionAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(WhyDoesSchemeHoldSharesPage(srn, index), SchemeHoldShare.Contribution)
+      .unsafeSet(WhenDidSchemeAcquireSharesPage(srn, index), localDate)
+
+  private def addSharesTransferAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(WhyDoesSchemeHoldSharesPage(srn, index), SchemeHoldShare.Transfer)
+
+  // Shares: Branching on IdentityTypePage
+  private def addSharesIndividualAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(IdentityTypePage(srn, index, SharesSeller), Individual)
+      .unsafeSet(IndividualNameOfSharesSellerPage(srn, index), name)
+      .unsafeSet(SharesIndividualSellerNINumberPage(srn, index), conditionalYesNoNino)
+
+  private def addSharesUKCompanyAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(IdentityTypePage(srn, index, SharesSeller), UKCompany)
+      .unsafeSet(CompanyNameOfSharesSellerPage(srn, index), name)
+      .unsafeSet(CompanyRecipientCrnPage(srn, index, SharesSeller), conditionalYesNoCrn)
+
+  private def addSharesUKPartnershipAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(IdentityTypePage(srn, index, SharesSeller), UKPartnership)
+      .unsafeSet(PartnershipShareSellerNamePage(srn, index), name)
+      .unsafeSet(PartnershipRecipientUtrPage(srn, index, SharesSeller), conditionalYesNoUtr)
+
+  private def addSharesOtherAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(IdentityTypePage(srn, index, SharesSeller), Other)
+      .unsafeSet(OtherRecipientDetailsPage(srn, index, SharesSeller), otherRecipientDetails)
+
+  // Special case: TotalAssetValuePage is only set when Sponsoring Employer & Acquisition are selected
+  private def addSharesSponsoringEmployerAndAcquisitionAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(TypeOfSharesHeldPage(srn, index), TypeOfShares.SponsoringEmployer)
+      .unsafeSet(WhyDoesSchemeHoldSharesPage(srn, index), SchemeHoldShare.Acquisition)
+      .unsafeSet(WhenDidSchemeAcquireSharesPage(srn, index), localDate)
+      .unsafeSet(TotalAssetValuePage(srn, index), money)
+
+  private def addSharesPrePopAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
+    userAnswers
+      .unsafeSet(SharesTotalIncomePage(srn, index), money)
+
+//--------------------------------------------------------------------------------------------------------------------//
 
   // Land or Property
   private val landOrPropertyHeldTrue = defaultUserAnswers.unsafeSet(LandOrPropertyHeldPage(srn), true)
@@ -48,7 +132,7 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
     userAnswers
       .unsafeSet(LandPropertyInUKPage(srn, index), true)
       .unsafeSet(LandOrPropertyChosenAddressPage(srn, index), address)
-      .unsafeSet(LandRegistryTitleNumberPage(srn, index), ConditionalYesNo.no[String, String](reason))
+      .unsafeSet(LandRegistryTitleNumberPage(srn, index), conditionalYesNoLRTN)
       .unsafeSet(LandOrPropertyTotalCostPage(srn, index), money)
 
   // LOP: Branching on WhyDoesSchemeHoldLandPropertyPage
@@ -74,19 +158,19 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
     userAnswers
       .unsafeSet(IdentityTypePage(srn, index, LandOrPropertySeller), Individual)
       .unsafeSet(LandPropertyIndividualSellersNamePage(srn, index), name)
-      .unsafeSet(IndividualSellerNiPage(srn, index), conditionalYesNino)
+      .unsafeSet(IndividualSellerNiPage(srn, index), conditionalYesNoNino)
 
   private def addLOPUKCompanyAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
     userAnswers
       .unsafeSet(IdentityTypePage(srn, index, LandOrPropertySeller), UKCompany)
       .unsafeSet(CompanySellerNamePage(srn, index), name)
-      .unsafeSet(CompanyRecipientCrnPage(srn, index, LandOrPropertySeller), conditionalYesCrn)
+      .unsafeSet(CompanyRecipientCrnPage(srn, index, LandOrPropertySeller), conditionalYesNoCrn)
 
   private def addLOPUKPartnershipAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
     userAnswers
       .unsafeSet(IdentityTypePage(srn, index, LandOrPropertySeller), UKPartnership)
       .unsafeSet(PartnershipSellerNamePage(srn, index), name)
-      .unsafeSet(PartnershipRecipientUtrPage(srn, index, LandOrPropertySeller), conditionalYesUtr)
+      .unsafeSet(PartnershipRecipientUtrPage(srn, index, LandOrPropertySeller), conditionalYesNoUtr)
 
   private def addLOPOtherAnswers(index: Max5000, userAnswers: UserAnswers): UserAnswers =
     userAnswers
@@ -100,6 +184,402 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
       .unsafeSet(LandOrPropertyLeaseDetailsPage(srn, index), (leaseName, money, localDate))
       .unsafeSet(IsLesseeConnectedPartyPage(srn, index), true)
       .unsafeSet(LandOrPropertyTotalIncomePage(srn, index), money)
+
+//--------------------------------------------------------------------------------------------------------------------//
+
+  "checkSharesSection" - {
+
+    "must be true" - {
+
+      "when didSchemeHoldAnyShares is Some(true) & 1 record is present, which needs checking" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesSponsoringEmployerAnswers(
+              index1of5000,
+              addSharesContributionAnswers(
+                index1of5000,
+                didSchemeHoldAnySharesTrue
+              )
+            )
+          )
+
+        checkSharesSection(userAnswers, srn) mustBe true
+      }
+
+      "when didSchemeHoldAnyShares is Some(true) & 2 records are present, 1 of which needs checking" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesUnquotedAnswers(
+              index1of5000,
+              addSharesTransferAnswers(
+                index1of5000,
+                addSharesBaseAnswers(
+                  index2of5000,
+                  addSharesConnectedPartyAnswers(
+                    index2of5000,
+                    addSharesContributionAnswers(
+                      index2of5000,
+                      addSharesPrePopAnswers(
+                        index2of5000,
+                        didSchemeHoldAnySharesTrue
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+
+        checkSharesSection(userAnswers, srn) mustBe true
+      }
+
+      "when didSchemeHoldAnyShares is None & 1 record is present, which needs checking" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesSponsoringEmployerAnswers(
+              index1of5000,
+              addSharesTransferAnswers(
+                index1of5000,
+                defaultUserAnswers
+              )
+            )
+          )
+
+        checkSharesSection(userAnswers, srn) mustBe true
+      }
+
+      "when didSchemeHoldAnyShares is None & when 2 records are present, 1 of which needs checking" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesUnquotedAnswers(
+              index1of5000,
+              addSharesContributionAnswers(
+                index1of5000,
+                addSharesBaseAnswers(
+                  index2of5000,
+                  addSharesConnectedPartyAnswers(
+                    index2of5000,
+                    addSharesTransferAnswers(
+                      index2of5000,
+                      addSharesPrePopAnswers(
+                        index2of5000,
+                        defaultUserAnswers
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+
+        checkSharesSection(userAnswers, srn) mustBe true
+      }
+    }
+
+    "must be false" - {
+
+      "when didSchemeHoldAnyShares is Some(false)" in {
+        val userAnswers = didSchemeHoldAnySharesFalse
+
+        checkSharesSection(userAnswers, srn) mustBe false
+      }
+
+      "when didSchemeHoldAnyShares is Some(true) & no records are present" in {
+        val userAnswers = didSchemeHoldAnySharesTrue
+
+        checkSharesSection(userAnswers, srn) mustBe false
+      }
+
+      "when didSchemeHoldAnyShares is Some(true) & 1 record is present which doesn't need checking" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesUnquotedAnswers(
+              index1of5000,
+              addSharesContributionAnswers(
+                index1of5000,
+                didSchemeHoldAnySharesTrue
+              )
+            )
+          ).unsafeRemove(SharesFromConnectedPartyPage(srn, index1of5000))
+
+        checkSharesSection(userAnswers, srn) mustBe false
+      }
+
+      "when didSchemeHoldAnyShares is None & no records are present" in {
+        val userAnswers = defaultUserAnswers
+
+        checkSharesSection(userAnswers, srn) mustBe false
+      }
+
+      "when didSchemeHoldAnyShares is None & 1 record is present which doesn't need checking" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesUnquotedAnswers(
+              index1of5000,
+              addSharesTransferAnswers(
+                index1of5000,
+                defaultUserAnswers
+              )
+            )
+          ).unsafeRemove(SharesFromConnectedPartyPage(srn, index1of5000))
+
+        checkSharesSection(userAnswers, srn) mustBe false
+      }
+    }
+  }
+
+  "checkSharesRecord" - {
+
+    "must be true" - {
+
+      "when pre-pop-cleared answer is missing and all other answers are present" - {
+
+        "(Acquisition & Sponsoring Employer & Individual)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesSponsoringEmployerAndAcquisitionAnswers(
+                index1of5000,
+                addSharesIndividualAnswers(
+                  index1of5000,
+                  didSchemeHoldAnySharesTrue
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Acquisition & Unquoted & UKCompany)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesUnquotedAnswers(
+                index1of5000,
+                addSharesAcquisitionAnswers(
+                  index1of5000,
+                  addSharesUKCompanyAnswers(
+                    index1of5000,
+                    didSchemeHoldAnySharesTrue
+                  )
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Acquisition & Connected Party & UKPartnership)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesConnectedPartyAnswers(
+                index1of5000,
+                addSharesAcquisitionAnswers(
+                  index1of5000,
+                  addSharesUKPartnershipAnswers(
+                    index1of5000,
+                    didSchemeHoldAnySharesTrue
+                  )
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Acquisition & Sponsoring Employer & Other)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesSponsoringEmployerAndAcquisitionAnswers(
+                index1of5000,
+                addSharesOtherAnswers(
+                  index1of5000,
+                  didSchemeHoldAnySharesTrue
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Contribution & Unquoted)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesUnquotedAnswers(
+                index1of5000,
+                addSharesContributionAnswers(
+                  index1of5000,
+                  didSchemeHoldAnySharesTrue
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Contribution & Sponsoring Employer)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesSponsoringEmployerAnswers(
+                index1of5000,
+                addSharesContributionAnswers(
+                  index1of5000,
+                  didSchemeHoldAnySharesTrue
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Transfer & Unquoted)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesUnquotedAnswers(
+                index1of5000,
+                addSharesTransferAnswers(
+                  index1of5000,
+                  didSchemeHoldAnySharesTrue
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Transfer & Connected Party)" in {
+          val userAnswers =
+            addSharesBaseAnswers(
+              index1of5000,
+              addSharesConnectedPartyAnswers(
+                index1of5000,
+                addSharesTransferAnswers(
+                  index1of5000,
+                  didSchemeHoldAnySharesTrue
+                )
+              )
+            )
+
+          checkSharesRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+      }
+    }
+
+    "must be false" - {
+
+      "when all answers are missing" in {
+        val userAnswers = defaultUserAnswers
+
+        checkSharesRecord(userAnswers, srn, index1of5000) mustBe false
+      }
+
+      "when 1 other answer is missing" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesSponsoringEmployerAndAcquisitionAnswers(
+              index1of5000,
+              addSharesIndividualAnswers(
+                index1of5000,
+                didSchemeHoldAnySharesTrue
+              )
+            )
+          ).unsafeRemove(IdentityTypePage(srn, index1of5000, SharesSeller))
+
+        checkSharesRecord(userAnswers, srn, index1of5000) mustBe false
+      }
+
+      "when all pre-pop-cleared answers are present" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesSponsoringEmployerAndAcquisitionAnswers(
+              index1of5000,
+              addSharesIndividualAnswers(
+                index1of5000,
+                addSharesPrePopAnswers(
+                  index1of5000,
+                  didSchemeHoldAnySharesTrue
+                )
+              )
+            )
+          )
+
+        checkSharesRecord(userAnswers, srn, index1of5000) mustBe false
+      }
+
+      "when Individual answers are missing" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesSponsoringEmployerAndAcquisitionAnswers(
+              index1of5000,
+              didSchemeHoldAnySharesTrue
+            )
+          ).unsafeSet(IdentityTypePage(srn, index1of5000, SharesSeller), Individual)
+
+        checkSharesRecord(userAnswers, srn, index1of5000) mustBe false
+      }
+
+      "when UKCompany answers are missing" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesAcquisitionAnswers(
+              index1of5000,
+              addSharesUnquotedAnswers(
+                index1of5000,
+                didSchemeHoldAnySharesTrue
+              )
+            )
+          ).unsafeSet(IdentityTypePage(srn, index1of5000, SharesSeller), UKCompany)
+
+        checkSharesRecord(userAnswers, srn, index1of5000) mustBe false
+      }
+
+      "when UKPartnership answers are missing" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesAcquisitionAnswers(
+              index1of5000,
+              addSharesConnectedPartyAnswers(
+                index1of5000,
+                didSchemeHoldAnySharesTrue
+              )
+            )
+          ).unsafeSet(IdentityTypePage(srn, index1of5000, SharesSeller), UKPartnership)
+
+        checkSharesRecord(userAnswers, srn, index1of5000) mustBe false
+      }
+
+      "when Other answer is missing" in {
+        val userAnswers =
+          addSharesBaseAnswers(
+            index1of5000,
+            addSharesSponsoringEmployerAndAcquisitionAnswers(
+              index1of5000,
+              didSchemeHoldAnySharesTrue
+            )
+          ).unsafeSet(IdentityTypePage(srn, index1of5000, SharesSeller), Other)
+
+        checkSharesRecord(userAnswers, srn, index1of5000) mustBe false
+      }
+    }
+  }
+
+//--------------------------------------------------------------------------------------------------------------------//
 
   "checkLandOrPropertySection" - {
 
@@ -234,94 +714,97 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
 
     "must be true" - {
 
-      "when all pre-pop-cleared answers are missing & all other answers are present (Acquisition & Individual)" in {
-        val userAnswers =
-          addLOPBaseAnswers(
-            index1of5000,
-            addLOPAcquisitionAnswers(
+      "when all pre-pop-cleared answers are missing & all other answers are present" - {
+
+        "(Acquisition & Individual)" in {
+          val userAnswers =
+            addLOPBaseAnswers(
               index1of5000,
-              addLOPIndividualAnswers(
+              addLOPAcquisitionAnswers(
+                index1of5000,
+                addLOPIndividualAnswers(
+                  index1of5000,
+                  landOrPropertyHeldTrue
+                )
+              )
+            )
+
+          checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Acquisition & UKCompany)" in {
+          val userAnswers =
+            addLOPBaseAnswers(
+              index1of5000,
+              addLOPAcquisitionAnswers(
+                index1of5000,
+                addLOPUKCompanyAnswers(
+                  index1of5000,
+                  landOrPropertyHeldTrue
+                )
+              )
+            )
+
+          checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Acquisition & UKPartnership)" in {
+          val userAnswers =
+            addLOPBaseAnswers(
+              index1of5000,
+              addLOPAcquisitionAnswers(
+                index1of5000,
+                addLOPUKPartnershipAnswers(
+                  index1of5000,
+                  landOrPropertyHeldTrue
+                )
+              )
+            )
+
+          checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Acquisition & Other)" in {
+          val userAnswers =
+            addLOPBaseAnswers(
+              index1of5000,
+              addLOPAcquisitionAnswers(
+                index1of5000,
+                addLOPOtherAnswers(
+                  index1of5000,
+                  landOrPropertyHeldTrue
+                )
+              )
+            )
+
+          checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
+        }
+
+        "(Contribution)" in {
+          val userAnswers =
+            addLOPBaseAnswers(
+              index1of5000,
+              addLOPContributionAnswers(
                 index1of5000,
                 landOrPropertyHeldTrue
               )
             )
-          )
 
-        checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
-      }
+          checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
+        }
 
-      "when all pre-pop-cleared answers are missing & all other answers are present (Acquisition & UKCompany)" in {
-        val userAnswers =
-          addLOPBaseAnswers(
-            index1of5000,
-            addLOPAcquisitionAnswers(
+        "(Transfer)" in {
+          val userAnswers =
+            addLOPBaseAnswers(
               index1of5000,
-              addLOPUKCompanyAnswers(
+              addLOPTransferAnswers(
                 index1of5000,
                 landOrPropertyHeldTrue
               )
             )
-          )
 
-        checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
-      }
-
-      "when all pre-pop-cleared answers are missing & all other answers are present (Acquisition & UKPartnership)" in {
-        val userAnswers =
-          addLOPBaseAnswers(
-            index1of5000,
-            addLOPAcquisitionAnswers(
-              index1of5000,
-              addLOPUKPartnershipAnswers(
-                index1of5000,
-                landOrPropertyHeldTrue
-              )
-            )
-          )
-
-        checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
-      }
-
-      "when all pre-pop-cleared answers are missing & all other answers are present (Acquisition & Other)" in {
-        val userAnswers =
-          addLOPBaseAnswers(
-            index1of5000,
-            addLOPAcquisitionAnswers(
-              index1of5000,
-              addLOPOtherAnswers(
-                index1of5000,
-                landOrPropertyHeldTrue
-              )
-            )
-          )
-
-        checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
-      }
-
-      "when all pre-pop-cleared answers are missing & all other answers are present (Contribution)" in {
-        val userAnswers =
-          addLOPBaseAnswers(
-            index1of5000,
-            addLOPContributionAnswers(
-              index1of5000,
-              landOrPropertyHeldTrue
-            )
-          )
-
-        checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
-      }
-
-      "when all pre-pop-cleared answers are missing & all other answers are present (Transfer)" in {
-        val userAnswers =
-          addLOPBaseAnswers(
-            index1of5000,
-            addLOPTransferAnswers(
-              index1of5000,
-              landOrPropertyHeldTrue
-            )
-          )
-
-        checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
+          checkLandOrPropertyRecord(userAnswers, srn, index1of5000) mustBe true
+        }
       }
 
       "when some pre-pop-cleared answers are present & some are missing" in {

--- a/test/utils/nonsipp/CheckStatusUtilsSpec.scala
+++ b/test/utils/nonsipp/CheckStatusUtilsSpec.scala
@@ -251,7 +251,7 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
         checkSharesSection(userAnswers, srn) mustBe true
       }
 
-      "when didSchemeHoldAnyShares is None & when 2 records are present, 1 of which needs checking" in {
+      "when didSchemeHoldAnyShares is None & 2 records are present, 1 of which needs checking" in {
         val userAnswers =
           addSharesBaseAnswers(
             index1of5000,
@@ -294,7 +294,7 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
         checkSharesSection(userAnswers, srn) mustBe false
       }
 
-      "when didSchemeHoldAnyShares is Some(true) & 1 record is present which doesn't need checking" in {
+      "when didSchemeHoldAnyShares is Some(true) & 1 record is present, which doesn't need checking" in {
         val userAnswers =
           addSharesBaseAnswers(
             index1of5000,
@@ -316,7 +316,7 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
         checkSharesSection(userAnswers, srn) mustBe false
       }
 
-      "when didSchemeHoldAnyShares is None & 1 record is present which doesn't need checking" in {
+      "when didSchemeHoldAnyShares is None & 1 record is present, which doesn't need checking" in {
         val userAnswers =
           addSharesBaseAnswers(
             index1of5000,
@@ -633,7 +633,7 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
         checkLandOrPropertySection(userAnswers, srn) mustBe true
       }
 
-      "when landOrPropertyHeld is None & when 2 records are present, 1 of which needs checking" in {
+      "when landOrPropertyHeld is None & 2 records are present, 1 of which needs checking" in {
         val userAnswers =
           addLOPBaseAnswers(
             index1of5000,
@@ -670,7 +670,7 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
         checkLandOrPropertySection(userAnswers, srn) mustBe false
       }
 
-      "when landOrPropertyHeld is Some(true) & 1 record is present which doesn't need checking" in {
+      "when landOrPropertyHeld is Some(true) & 1 record is present, which doesn't need checking" in {
         val userAnswers =
           addLOPBaseAnswers(
             index1of5000,
@@ -692,7 +692,7 @@ class CheckStatusUtilsSpec extends ControllerBaseSpec with Matchers with OptionV
         checkLandOrPropertySection(userAnswers, srn) mustBe false
       }
 
-      "when landOrPropertyHeld is None & 1 record is present which doesn't need checking" in {
+      "when landOrPropertyHeld is None & 1 record is present, which doesn't need checking" in {
         val userAnswers =
           addLOPBaseAnswers(
             index1of5000,

--- a/test/utils/nonsipp/PrePopulationUtilsSpec.scala
+++ b/test/utils/nonsipp/PrePopulationUtilsSpec.scala
@@ -27,16 +27,22 @@ import config.Constants.PREPOPULATION_FLAG
 
 class PrePopulationUtilsSpec extends ControllerBaseSpec with Matchers with OptionValues {
 
-  implicit val request: DataRequest[AnyContentAsEmpty.type] = DataRequest(allowedAccessRequestGen(FakeRequest()).sample.value, defaultUserAnswers)
-  implicit val requestWithFlagTrue: DataRequest[AnyContentAsEmpty.type] = DataRequest(allowedAccessRequestGen(
-    FakeRequest()
-      .withSession((PREPOPULATION_FLAG, "true"))
-  ).sample.value, defaultUserAnswers)
-  implicit val requestWithFlagFalse: DataRequest[AnyContentAsEmpty.type] = DataRequest(allowedAccessRequestGen(
-    FakeRequest()
-      .withSession((PREPOPULATION_FLAG, "false"))
-  ).sample.value, defaultUserAnswers)
-
+  implicit val request: DataRequest[AnyContentAsEmpty.type] =
+    DataRequest(allowedAccessRequestGen(FakeRequest()).sample.value, defaultUserAnswers)
+  implicit val requestWithFlagTrue: DataRequest[AnyContentAsEmpty.type] = DataRequest(
+    allowedAccessRequestGen(
+      FakeRequest()
+        .withSession((PREPOPULATION_FLAG, "true"))
+    ).sample.value,
+    defaultUserAnswers
+  )
+  implicit val requestWithFlagFalse: DataRequest[AnyContentAsEmpty.type] = DataRequest(
+    allowedAccessRequestGen(
+      FakeRequest()
+        .withSession((PREPOPULATION_FLAG, "false"))
+    ).sample.value,
+    defaultUserAnswers
+  )
 
   "isPrePopulation" - {
 


### PR DESCRIPTION
This PR includes the implementation of the Shares Check methods and tests, as well as some non-functional changes to the LOP Check methods and tests.

Specifically, the changes from line 584 onwards in CheckStatusUtilsSpec can be ignored, as the only changes made there are renaming and nesting some tests differently, without changing any part of the code within those tests.