### PR TITLE
PSR-1686 | Implement currency pattern (a11y)

### DIFF
--- a/app/controllers/nonsipp/bonds/CostOfBondsController.scala
+++ b/app/controllers/nonsipp/bonds/CostOfBondsController.scala
@@ -111,7 +111,7 @@ object CostOfBondsController {
       Message("bonds.costOfBonds.heading"),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("bonds.costOfBonds.hint"))
+        QuestionField.currency(Empty, Some("bonds.costOfBonds.hint"))
       ),
       controllers.nonsipp.bonds.routes.CostOfBondsController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/bonds/IncomeFromBondsController.scala
+++ b/app/controllers/nonsipp/bonds/IncomeFromBondsController.scala
@@ -116,7 +116,7 @@ object IncomeFromBondsController {
       Message("bonds.incomeFromBonds.heading"),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("bonds.incomeFromBonds.hint"))
+        QuestionField.currency(Empty, Some("bonds.incomeFromBonds.hint"))
       ),
       controllers.nonsipp.bonds.routes.IncomeFromBondsController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/bondsdisposal/TotalConsiderationSaleBondsController.scala
+++ b/app/controllers/nonsipp/bondsdisposal/TotalConsiderationSaleBondsController.scala
@@ -111,7 +111,7 @@ object TotalConsiderationSaleBondsController {
     FormPageViewModel(
       title = Message("bondsDisposal.totalConsiderationBondsSold.title"),
       heading = Message("bondsDisposal.totalConsiderationBondsSold.heading"),
-      page = SingleQuestion(form, QuestionField.input(Empty)),
+      page = SingleQuestion(form, QuestionField.currency(Empty)),
       onSubmit = routes.TotalConsiderationSaleBondsController.onSubmit(srn, bondIndex, disposalIndex, mode)
     )
 }

--- a/app/controllers/nonsipp/employercontributions/TotalEmployerContributionController.scala
+++ b/app/controllers/nonsipp/employercontributions/TotalEmployerContributionController.scala
@@ -139,7 +139,7 @@ object TotalEmployerContributionController {
       Message("totalEmployerContribution.heading", employerName, memberName),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("totalEmployerContribution.hint"))
+        QuestionField.currency(Empty, Some("totalEmployerContribution.hint"))
       ),
       controllers.nonsipp.employercontributions.routes.TotalEmployerContributionController
         .onSubmit(srn, index, secondaryIndex, mode)

--- a/app/controllers/nonsipp/landorproperty/LandOrPropertyTotalCostController.scala
+++ b/app/controllers/nonsipp/landorproperty/LandOrPropertyTotalCostController.scala
@@ -108,7 +108,7 @@ object LandOrPropertyTotalCostController {
       Message("landOrPropertyTotalCost.heading", addressLine1),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("landOrPropertyTotalCost.hint"))
+        QuestionField.currency(Empty, Some("landOrPropertyTotalCost.hint"))
       ),
       routes.LandOrPropertyTotalCostController.onSubmit(srn, index, mode)
     )

--- a/app/controllers/nonsipp/landorproperty/LandOrPropertyTotalIncomeController.scala
+++ b/app/controllers/nonsipp/landorproperty/LandOrPropertyTotalIncomeController.scala
@@ -111,7 +111,7 @@ object LandOrPropertyTotalIncomeController {
       Message("landOrPropertyTotalIncome.heading", addressLine1),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("landOrPropertyTotalIncome.hint"))
+        QuestionField.currency(Empty, Some("landOrPropertyTotalIncome.hint"))
       ),
       controllers.nonsipp.landorproperty.routes.LandOrPropertyTotalIncomeController.onSubmit(srn, index, mode)
     )

--- a/app/controllers/nonsipp/landorpropertydisposal/TotalProceedsSaleLandPropertyController.scala
+++ b/app/controllers/nonsipp/landorpropertydisposal/TotalProceedsSaleLandPropertyController.scala
@@ -129,7 +129,7 @@ object TotalProceedsSaleLandPropertyController {
       details = None,
       page = SingleQuestion(
         form,
-        QuestionField.input(
+        QuestionField.currency(
           Empty,
           Some(
             ParagraphMessage("totalProceedsSaleLandProperty.paragraph") ++

--- a/app/controllers/nonsipp/loansmadeoroutstanding/AmountOfTheLoanController.scala
+++ b/app/controllers/nonsipp/loansmadeoroutstanding/AmountOfTheLoanController.scala
@@ -173,9 +173,9 @@ object AmountOfTheLoanController {
       Message("amountOfTheLoan.heading", schemeName),
       page = TripleQuestion(
         form,
-        QuestionField.input(Message("amountOfTheLoan.loanAmount.label")),
-        QuestionField.input(Message("amountOfTheLoan.capRepaymentCY.label")),
-        QuestionField.input(Message("amountOfTheLoan.amountOutstanding.label", period.to.show))
+        QuestionField.currency(Message("amountOfTheLoan.loanAmount.label")),
+        QuestionField.currency(Message("amountOfTheLoan.capRepaymentCY.label")),
+        QuestionField.currency(Message("amountOfTheLoan.amountOutstanding.label", period.to.show))
       ),
       routes.AmountOfTheLoanController.onSubmit(srn, index, mode)
     )

--- a/app/controllers/nonsipp/membercontributions/TotalMemberContributionController.scala
+++ b/app/controllers/nonsipp/membercontributions/TotalMemberContributionController.scala
@@ -132,7 +132,7 @@ object TotalMemberContributionController {
       Message("totalMemberContribution.heading", memberName),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("totalMemberContribution.hint"))
+        QuestionField.currency(Empty, Some("totalMemberContribution.hint"))
       ),
       controllers.nonsipp.membercontributions.routes.TotalMemberContributionController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/memberpayments/UnallocatedEmployerAmountController.scala
+++ b/app/controllers/nonsipp/memberpayments/UnallocatedEmployerAmountController.scala
@@ -106,7 +106,7 @@ object UnallocatedEmployerAmountController {
       Message("unallocatedEmployerAmount.heading", schemeName),
       SingleQuestion(
         form,
-        QuestionField.input(Empty)
+        QuestionField.currency(Empty)
       ),
       controllers.nonsipp.memberpayments.routes.UnallocatedEmployerAmountController.onSubmit(srn, mode)
     )

--- a/app/controllers/nonsipp/memberpensionpayments/TotalAmountPensionPaymentsController.scala
+++ b/app/controllers/nonsipp/memberpensionpayments/TotalAmountPensionPaymentsController.scala
@@ -131,7 +131,7 @@ object TotalAmountPensionPaymentsController {
       Message("totalAmountPensionPayments.heading", memberName),
       SingleQuestion(
         form,
-        QuestionField.input(Empty)
+        QuestionField.currency(Empty)
       ),
       controllers.nonsipp.memberpensionpayments.routes.TotalAmountPensionPaymentsController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/membersurrenderedbenefits/SurrenderedBenefitsAmountController.scala
+++ b/app/controllers/nonsipp/membersurrenderedbenefits/SurrenderedBenefitsAmountController.scala
@@ -113,7 +113,7 @@ object SurrenderedBenefitsAmountController {
     FormPageViewModel(
       title = "surrenderedBenefits.amount.title",
       heading = Message("surrenderedBenefits.amount.heading", memberName),
-      page = SingleQuestion(form, QuestionField.input(Empty)),
+      page = SingleQuestion(form, QuestionField.currency(Empty)),
       onSubmit = routes.SurrenderedBenefitsAmountController.onSubmit(srn, memberIndex, mode)
     )
 }

--- a/app/controllers/nonsipp/moneyborrowed/ValueOfSchemeAssetsWhenMoneyBorrowedController.scala
+++ b/app/controllers/nonsipp/moneyborrowed/ValueOfSchemeAssetsWhenMoneyBorrowedController.scala
@@ -129,7 +129,7 @@ object ValueOfSchemeAssetsWhenMoneyBorrowedController {
       Message("valueOfSchemeAssetsWhenMoneyBorrowed.heading", schemeName, date),
       SingleQuestion(
         form,
-        QuestionField.input(Empty)
+        QuestionField.currency(Empty)
       ),
       routes.ValueOfSchemeAssetsWhenMoneyBorrowedController.onSubmit(srn, index, mode)
     )

--- a/app/controllers/nonsipp/otherassetsdisposal/TotalConsiderationSaleAssetController.scala
+++ b/app/controllers/nonsipp/otherassetsdisposal/TotalConsiderationSaleAssetController.scala
@@ -111,7 +111,7 @@ object TotalConsiderationSaleAssetController {
     FormPageViewModel(
       title = Message("totalConsiderationSaleAsset.title"),
       heading = Message("totalConsiderationSaleAsset.heading"),
-      page = SingleQuestion(form, QuestionField.input(Empty)),
+      page = SingleQuestion(form, QuestionField.currency(Empty)),
       onSubmit = routes.TotalConsiderationSaleAssetController.onSubmit(srn, assetIndex, disposalIndex, mode)
     )
 }

--- a/app/controllers/nonsipp/otherassetsheld/CostOfOtherAssetController.scala
+++ b/app/controllers/nonsipp/otherassetsheld/CostOfOtherAssetController.scala
@@ -111,7 +111,7 @@ object CostOfOtherAssetController {
       Message("otherAssets.costOfOtherAsset.heading"),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("otherAssets.costOfOtherAsset.hint"))
+        QuestionField.currency(Empty, Some("otherAssets.costOfOtherAsset.hint"))
       ),
       controllers.nonsipp.otherassetsheld.routes.CostOfOtherAssetController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/otherassetsheld/IncomeFromAssetController.scala
+++ b/app/controllers/nonsipp/otherassetsheld/IncomeFromAssetController.scala
@@ -116,7 +116,7 @@ object IncomeFromAssetController {
       Message("otherAssets.incomeFromAsset.heading"),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("otherAssets.incomeFromAsset.hint"))
+        QuestionField.currency(Empty, Some("otherAssets.incomeFromAsset.hint"))
       ),
       controllers.nonsipp.otherassetsheld.routes.IncomeFromAssetController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/receivetransfer/TotalValueTransferController.scala
+++ b/app/controllers/nonsipp/receivetransfer/TotalValueTransferController.scala
@@ -138,7 +138,7 @@ object TotalValueTransferController {
       Message("totalValueTransfer.heading", transferSchemeName, memberName),
       SingleQuestion(
         form,
-        QuestionField.input(Empty)
+        QuestionField.currency(Empty)
       ),
       controllers.nonsipp.receivetransfer.routes.TotalValueTransferController
         .onSubmit(srn, index, secondaryIndex, mode)

--- a/app/controllers/nonsipp/shares/CostOfSharesController.scala
+++ b/app/controllers/nonsipp/shares/CostOfSharesController.scala
@@ -119,7 +119,7 @@ object CostOfSharesController {
       ),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("shares.costOfShares.hint"))
+        QuestionField.currency(Empty, Some("shares.costOfShares.hint"))
       ),
       controllers.nonsipp.shares.routes.CostOfSharesController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/shares/SharesTotalIncomeController.scala
+++ b/app/controllers/nonsipp/shares/SharesTotalIncomeController.scala
@@ -107,7 +107,7 @@ object SharesTotalIncomeController {
       Message("sharesTotalIncome.heading", companyName),
       SingleQuestion(
         form,
-        QuestionField.input(Empty, Some("sharesTotalIncome.hint"))
+        QuestionField.currency(Empty, Some("sharesTotalIncome.hint"))
       ),
       routes.SharesTotalIncomeController.onSubmit(srn, index, mode)
     )

--- a/app/controllers/nonsipp/shares/TotalAssetValueController.scala
+++ b/app/controllers/nonsipp/shares/TotalAssetValueController.scala
@@ -123,7 +123,7 @@ object TotalAssetValueController {
       ),
       SingleQuestion(
         form,
-        QuestionField.input(Empty)
+        QuestionField.currency(Empty)
       ),
       routes.TotalAssetValueController
         .onSubmit(srn, index, mode)

--- a/app/controllers/nonsipp/sharesdisposal/TotalConsiderationSharesRedeemedController.scala
+++ b/app/controllers/nonsipp/sharesdisposal/TotalConsiderationSharesRedeemedController.scala
@@ -130,7 +130,7 @@ object TotalConsiderationSharesRedeemedController {
     FormPageViewModel(
       title = Message("sharesDisposal.totalConsiderationSharesRedeemed.title"),
       heading = Message("sharesDisposal.totalConsiderationSharesRedeemed.heading", numShares, companyName),
-      page = SingleQuestion(form, QuestionField.input(Empty)),
+      page = SingleQuestion(form, QuestionField.currency(Empty)),
       onSubmit = routes.TotalConsiderationSharesRedeemedController.onSubmit(srn, shareIndex, disposalIndex, mode)
     )
 }

--- a/app/controllers/nonsipp/sharesdisposal/TotalConsiderationSharesSoldController.scala
+++ b/app/controllers/nonsipp/sharesdisposal/TotalConsiderationSharesSoldController.scala
@@ -125,7 +125,7 @@ object TotalConsiderationSharesSoldController {
     FormPageViewModel(
       title = Message("sharesDisposal.totalConsiderationSharesSold.title"),
       heading = Message("sharesDisposal.totalConsiderationSharesSold.heading", numShares, companyName),
-      page = SingleQuestion(form, QuestionField.input(Empty)),
+      page = SingleQuestion(form, QuestionField.currency(Empty)),
       onSubmit = routes.TotalConsiderationSharesSoldController.onSubmit(srn, shareIndex, disposalIndex, mode)
     )
 }

--- a/app/controllers/nonsipp/totalvaluequotedshares/TotalValueQuotedSharesController.scala
+++ b/app/controllers/nonsipp/totalvaluequotedshares/TotalValueQuotedSharesController.scala
@@ -124,7 +124,7 @@ object TotalValueQuotedSharesController {
       Message("totalValueQuotedShares.heading", schemeName, period.to.show),
       SingleQuestion(
         form,
-        QuestionField.input(Empty)
+        QuestionField.currency(Empty)
       ),
       routes.TotalValueQuotedSharesController.onSubmit(srn)
     )


### PR DESCRIPTION
The only visible change in this ticket is the addition of the £ prefixes for each field in `AmountOfTheLoanController`.

Additionally, I noticed that our code uses `QuestionField.input(...)` for some `Money` fields, and `QuestionField.currency(...)` for other `Money` fields, so I changed each such `.input` to `.currency`, for consistency. This can be reverted if necessary.