### PR TITLE
PSR-1648 | [Accessibility] Issue: Multiple H1s #8732 (page 5 - yes) (P1)

### DIFF
--- a/app/viewmodels/govuk/RadiosFluency.scala
+++ b/app/viewmodels/govuk/RadiosFluency.scala
@@ -179,7 +179,6 @@ trait RadiosFluency {
                     case _ => heading.toString
                   }
                 ).asPageHeading(LegendSize.Large)
-                  .withCssClass("govuk-visually-hidden")
               )
           )
         ),

--- a/app/views/ConditionalYesNoPageView.scala.html
+++ b/app/views/ConditionalYesNoPageView.scala.html
@@ -35,9 +35,11 @@
       @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    <h1 class="govuk-heading-l">@renderMessage(viewModel.heading)</h1>
+    @if(viewModel.page.legend.nonEmpty) {
+      <h1 class="govuk-heading-l">@renderMessage(viewModel.heading)</h1>
+    }
 
-    @if(viewModel.page.hint.nonEmpty) {
+    @if(viewModel.page.legend.nonEmpty) {
       <div class="govuk-hint">@viewModel.page.hint.map(renderMessage)</div>
     }
 
@@ -63,6 +65,7 @@
         legend = viewModel.page.legend,
         heading = viewModel.heading
       )
+      .withHint(viewModel.page.hint.map(hint => Hint(content = HtmlContent(renderMessage(hint)))))
       .withAttribute("id" -> "value")
     )
 


### PR DESCRIPTION
**Issue:**
- [Multiple H1's](https://github.com/hmrc/accessibility-audits-external/issues/8732)

**Dev Tasks:**
- [x] Move hint text into fieldset after the legend
- [x] Make sure unit tests pass
- [x] Make sure PR build is green
##

### FYI:
- This PR is only fixing _Number 2 Page_:

<img width="684" alt="390569732-70d6815f-f9e8-43c0-b276-42eeeb4b95fe" src="https://github.com/user-attachments/assets/db363e29-8b9e-4e53-9087-0bd6686a6c3d">

- _Number 1 Page_ will be addressed in a separate [Ticket](https://jira.tools.tax.service.gov.uk/browse/PSR-1649) and [PR](https://github.com/hmrc/pension-scheme-return-frontend/pull/990). It was intentionally excluded from this PR to avoid conflicts between multiple PRs.

- _Number 3 Page's_ will be addressed in a separate ticket as it needs to go through design team again.