### PR TITLE
PSR-1670 | Add month names

### DIFF
--- a/app/forms/mappings/LocalDateFormatter.scala
+++ b/app/forms/mappings/LocalDateFormatter.scala
@@ -24,7 +24,7 @@ import forms.mappings.errors.{DateFormErrors, IntFormErrors}
 
 import scala.util.{Failure, Success, Try}
 
-import java.time.LocalDate
+import java.time.{LocalDate, Month}
 
 private[mappings] class LocalDateFormatter(
   dateFormErrors: DateFormErrors,
@@ -63,7 +63,9 @@ private[mappings] class LocalDateFormatter(
 
     val validated = (
       int(dateFormErrors.requiredDay, 31).bind(s"$key.day", data).toValidated,
-      int(dateFormErrors.requiredMonth, 12).bind(s"$key.month", data).toValidated,
+      MonthFormatter(dateFormErrors.requiredMonth, dateFormErrors.invalidCharacters, args)
+        .bind(s"$key.month", data)
+        .toValidated,
       int(dateFormErrors.requiredYear, 9999).bind(s"$key.year", data).toValidated
     ).tupled.toEither
 
@@ -122,4 +124,38 @@ private[mappings] class LocalDateFormatter(
       s"$key.month" -> value.getMonthValue.toString,
       s"$key.year" -> value.getYear.toString
     )
+}
+
+private object MonthFormatter extends Formatters {
+
+  def apply(requiredKey: String, invalidKey: String, args: Seq[String] = Seq.empty): Formatter[Int] =
+    new Formatter[Int] {
+
+      private val MinMonth = 1
+      private val MaxMonth = 12
+      private val MonthAbbreviationLength = 3
+
+      override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Int] =
+        data.get(key).map(_.trim).filter(_.nonEmpty) match {
+
+          case None => Left(List(FormError(key, requiredKey, args)))
+          case Some(value) =>
+            val normalizedString = value.toUpperCase
+
+            normalizedString.toIntOption match {
+              case Some(number) if number >= MinMonth && number <= MaxMonth => Right(number)
+              case _ =>
+                Month.values.toList
+                  .find(
+                    m =>
+                      m.toString.toUpperCase == normalizedString ||
+                        m.toString.take(MonthAbbreviationLength).toUpperCase == normalizedString
+                  )
+                  .map(_.getValue)
+                  .toRight(List(FormError(key, invalidKey, args)))
+            }
+        }
+
+      override def unbind(key: String, value: Int): Map[String, String] = Map(key -> value.toString)
+    }
 }

--- a/test/forms/DateMappingsSpec.scala
+++ b/test/forms/DateMappingsSpec.scala
@@ -435,4 +435,25 @@ class DateMappingsSpec
       filledForm("value.year").value.value mustEqual date.getYear.toString
     }
   }
+
+  "must bind valid month data with short and full month names" in {
+
+    val validMonths = Table(
+      ("day", "month", "year", "expectedMonthValue"),
+      ("01", "Jan", "2020", 1),
+      ("01", "January", "2020", 1),
+      ("15", "Feb", "2021", 2),
+      ("15", "February", "2021", 2)
+    )
+
+    forAll(validMonths) { (day, month, year, expectedMonthValue) =>
+      val data = Map("value.day" -> day, "value.month" -> month, "value.year" -> year)
+
+      val result = form.bind(data)
+
+      result.value.value.getDayOfMonth mustEqual day.toInt
+      result.value.value.getMonthValue mustEqual expectedMonthValue
+      result.value.value.getYear mustEqual year.toInt
+    }
+  }
 }

--- a/test/forms/DateMappingsSpec.scala
+++ b/test/forms/DateMappingsSpec.scala
@@ -456,4 +456,24 @@ class DateMappingsSpec
       result.value.value.getYear mustEqual year.toInt
     }
   }
+
+  "must fail to bind invalid month names" in {
+
+    val invalidMonths = Table(
+      ("day", "month", "year", "expectedError"),
+      ("01", "Febru", "2020", "error.invalid.characters"),
+      ("01", "Februaryys", "2020", "error.invalid.characters"),
+      ("15", "AnyText", "2021", "error.invalid.characters")
+    )
+
+    forAll(invalidMonths) { (day, month, year, expectedError) =>
+      val data = Map("value.day" -> day, "value.month" -> month, "value.year" -> year)
+
+      val result = form.bind(data)
+
+      result.errors must have size 1
+      result.errors.head.key mustEqual "value.month"
+      result.errors.head.message mustEqual expectedError
+    }
+  }
 }


### PR DESCRIPTION
**Issue:**
- [Month field doesn’t accept month name](https://github.com/hmrc/accessibility-audits-external/issues/8753)

**Dev Tasks:**
- [x] Make sure month field accepts month names eg: "jan" "January"
- [x] Make sure unit tests pass
- [x] Make sure build is green