### PR TITLE
PSR-1670-2 | Allow month input with spaces

### DIFF
--- a/app/forms/mappings/LocalDateFormatter.scala
+++ b/app/forms/mappings/LocalDateFormatter.scala
@@ -140,7 +140,7 @@ private object MonthFormatter extends Formatters {
 
           case None => Left(List(FormError(key, requiredKey, args)))
           case Some(value) =>
-            val normalizedString = value.toUpperCase
+            val normalizedString = value.toUpperCase.replaceAll("\\s+", "")
 
             normalizedString.toIntOption match {
               case Some(number) if number >= MinMonth && number <= MaxMonth => Right(number)

--- a/test/forms/DateMappingsSpec.scala
+++ b/test/forms/DateMappingsSpec.scala
@@ -443,7 +443,9 @@ class DateMappingsSpec
       ("01", "Jan", "2020", 1),
       ("01", "January", "2020", 1),
       ("15", "Feb", "2021", 2),
-      ("15", "February", "2021", 2)
+      ("15", "February", "2021", 2),
+      ("20", " D e c e m b e r ", "2021", 12),
+      ("20", " Dec ", "2021", 12)
     )
 
     forAll(validMonths) { (day, month, year, expectedMonthValue) =>


### PR DESCRIPTION
**Dev Tasks:**

- [x] - Allow inputs for month in such manner -> " J a n ", " J a n u a r y ", " 0 1 "... etc..
- [x] - Make sure tests pass.
- [x] - Make sure PR check builds is green.