### PR TITLE
PSR-2114: update return submitted link

### DIFF
--- a/app/config/Constants.scala
+++ b/app/config/Constants.scala
@@ -42,6 +42,8 @@ object Constants {
   val VERSION = "version"
   val FB_NUMBER = "fbNumber"
 
+  val IS_JOURNEY_BYPASSED = "isJourneyBypassed"
+
   val delimitedPSA = "DELIMITED_PSAID"
   val detailsNotFound = "no match found"
 

--- a/app/controllers/nonsipp/declaration/PsaDeclarationController.scala
+++ b/app/controllers/nonsipp/declaration/PsaDeclarationController.scala
@@ -31,7 +31,7 @@ import viewmodels.implicits._
 import utils.nonsipp.MemberCountUtils.hasMemberNumbersChangedToOver99
 import views.html.ContentPageView
 import models.SchemeId.Srn
-import pages.nonsipp.FbVersionPage
+import pages.nonsipp.{FbVersionPage, WhichTaxYearPage}
 import navigation.Navigator
 import utils.nonsipp.SchemeDetailNavigationUtils
 import uk.gov.hmrc.http.HeaderCarrier
@@ -146,6 +146,15 @@ class PsaDeclarationController @Inject() (
           } yield Redirect(navigator.nextPage(PsaDeclarationPage(srn), NormalMode, request.userAnswers))
             .addingToSession((RETURN_PERIODS, schemeDateService.returnPeriodsAsJsonString(srn)))
             .addingToSession((SUBMISSION_DATE, schemeDateService.submissionDateAsString(now)))
+            .addingToSession(
+              (TAX_YEAR, request.userAnswers.get(WhichTaxYearPage(srn)).map(_.from.getYear.toString).getOrElse(""))
+            )
+            .addingToSession(
+              (
+                IS_JOURNEY_BYPASSED,
+                bypassed.toString
+              )
+            )
       }
     }
 

--- a/app/controllers/nonsipp/declaration/PspDeclarationController.scala
+++ b/app/controllers/nonsipp/declaration/PspDeclarationController.scala
@@ -31,7 +31,7 @@ import viewmodels.implicits._
 import utils.nonsipp.MemberCountUtils.hasMemberNumbersChangedToOver99
 import views.html.PsaIdInputView
 import models.SchemeId.Srn
-import pages.nonsipp.FbVersionPage
+import pages.nonsipp.{FbVersionPage, WhichTaxYearPage}
 import navigation.Navigator
 import utils.nonsipp.SchemeDetailNavigationUtils
 import forms.TextFormProvider
@@ -165,6 +165,18 @@ class PspDeclarationController @Inject() (
                   .addingToSession((RETURN_PERIODS, schemeDateService.returnPeriodsAsJsonString(srn)))
                   .addingToSession(
                     (SUBMISSION_DATE, schemeDateService.submissionDateAsString(now))
+                  )
+                  .addingToSession(
+                    (
+                      TAX_YEAR,
+                      request.userAnswers.get(WhichTaxYearPage(srn)).map(_.from.getYear.toString).getOrElse("")
+                    )
+                  )
+                  .addingToSession(
+                    (
+                      IS_JOURNEY_BYPASSED,
+                      bypassed.toString
+                    )
                   )
             )
       }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,7 +11,7 @@ object AppDependencies {
     "uk.gov.hmrc"        %% "play-conditional-form-mapping-play-30"  % "3.3.0",
     "uk.gov.hmrc"        %% "bootstrap-frontend-play-30"             % bootstrapVersion,
     "uk.gov.hmrc"        %% "tax-year"                               % "6.0.0",
-    "uk.gov.hmrc"        %% "domain-play-30"                         % "12.1.0",
+    "uk.gov.hmrc"        %% "domain-play-30"                         % "13.0.0",
     "uk.gov.hmrc"        %% "crypto-json-play-30"                    % "8.3.0",
     "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-30"                     % hmrcMongoVersion,
     "org.typelevel"      %% "cats-core"                              % "2.13.0",

--- a/test/controllers/nonsipp/ReturnSubmittedControllerSpec.scala
+++ b/test/controllers/nonsipp/ReturnSubmittedControllerSpec.scala
@@ -39,9 +39,7 @@ class ReturnSubmittedControllerSpec extends ControllerBaseSpec with ControllerBe
   private val returnPeriod3 = dateRangeGen.sample.value
   private val submissionDateTime = localDateTimeGen.sample.value
 
-  private val startDate = returnPeriod1.from.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
   private val mpsDashboardUrl = "http://localhost:8204/manage-pension-schemes/pension-scheme-summary/" + srn.value
-  private val summaryUrl = controllers.nonsipp.declaration.routes.SummaryController.onPageLoad(srn, startDate).url
 
   "ReturnSubmittedController" - {
 
@@ -107,6 +105,6 @@ class ReturnSubmittedControllerSpec extends ControllerBaseSpec with ControllerBe
       returnPeriods,
       submissionDate,
       mpsDashboardUrl,
-      summaryUrl
+      None
     )
 }


### PR DESCRIPTION
* Hide link for over 99 members scenario
* use the correct date for the return submitted page link in the event the accounting periods don't start at the beginning of the tax year.